### PR TITLE
Some code improvements

### DIFF
--- a/src/rng2doc/common.py
+++ b/src/rng2doc/common.py
@@ -64,9 +64,9 @@ NSMAP = dict(a="http://relaxng.org/ns/compatibility/annotations/1.0",
              db="http://docbook.org/ns/docbook",
              html="http://www.w3.org/1999/xhtml",
              rng="http://relaxng.org/ns/structure/1.0",
-             s="http://purl.oclc.org/dsdl/schematron",
              xlink="http://www.w3.org/1999/xlink",
              sch="http://purl.oclc.org/dsdl/schematron",
+             xml="http://www.w3.org/XML/1998/namespace",
              )
 
 # Relax NG namespace
@@ -105,6 +105,10 @@ SCH_PARAM = QName(NSMAP['sch'], "param")
 SCH_RULE = QName(NSMAP['sch'], "rule")
 
 A_DOC = QName(NSMAP['a'], "documentation")
+
+#: Stylesheets
+HTML_XSLT = "xslt/html.xslt"
+
 
 #: Map verbosity to log levels
 LOGLEVELS = {None: WARNING,  # 0

--- a/src/rng2doc/rng.py
+++ b/src/rng2doc/rng.py
@@ -103,11 +103,9 @@ def add_unique_index(elements):
     :return: The same list of etree.Elements with a unique index.
     :rtype: A list of etree.Element
     """
-    index = 0
-    for element in elements:
+    for index, element in enumerate(elements):
         uuid = "{}".format(index)
         element.attrib["id"] = uuid
-        index += 1
     return elements
 
 

--- a/src/rng2doc/transforms/xml.py
+++ b/src/rng2doc/transforms/xml.py
@@ -9,6 +9,7 @@ from lxml import etree
 
 # Local imports
 from ..common import (A_DOC,
+                      NSMAP,
                       RNG_ATTRIBUTE,
                       RNG_CHOICE,
                       RNG_DATA,
@@ -16,7 +17,8 @@ from ..common import (A_DOC,
                       RNG_OPTIONAL,
                       RNG_PARAM,
                       RNG_TEXT,
-                      RNG_VALUE)
+                      RNG_VALUE,
+                      )
 
 LOG = logging.getLogger(__name__)
 
@@ -30,7 +32,7 @@ def find_namespace(node):
         if prefix in node.nsmap:
             return node.nsmap[prefix]
         elif prefix == "xml":
-            return "http://www.w3.org/XML/1998/namespace"
+            return NSMAP['xml']
     namespace = node.get("ns")
     if namespace:
         return namespace

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -122,9 +122,13 @@ def test_parse(mock_parse):
          ("boolean(/documentation/element[@name = 'root']/child[@id = '2'])", True),
          ("boolean(/documentation/element[@name = 'test1'])", True),
          ("boolean(/documentation/element[@name = 'test2'])", True),
-     ]
-    )
-])
+     ],
+    )],
+    ids=['E.test',
+         'G.start.test',
+         'E.root.test',
+         'E.root.(test1,test2)'],
+)
 def test_transform_element(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)
@@ -203,9 +207,11 @@ def test_transform_element(xml, expected):
            True),
          ("boolean(/documentation/element[@name = 'element1']/attribute[@name = 'test3'])",
            True),
-     ]
-    ),
-])
+     ])
+    ],
+    ids=['E.root.@test',
+         'E.root.(@test1,@test2).element1'],
+)
 def test_transform_attribute(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)
@@ -306,8 +312,11 @@ def test_transform_attribute(xml, expected):
          ("/documentation/element[@name = 'root']/attribute[1]/use/text()",
           ["required"]),
      ]
-    ),
-])
+    )],
+    ids=['E.root.@test?',
+         'E.root.(@test?,@test2,@test3?)',
+         'E.root.@test'],
+)
 def test_transform_optional(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)
@@ -347,8 +356,9 @@ def test_transform_optional(xml, expected):
          ("/documentation/element[@name = 'root']/attribute/description/text()",
           ["This is a test attribute."]),
      ]
-    ),
-])
+    )],
+    ids=['E.a:doc'],
+)
 def test_transform_annotations(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)
@@ -435,8 +445,11 @@ def test_transform_annotations(xml, expected):
          ("/documentation/element[@name = 'root']/attribute/type/description/text()",
           ["This is a test datatype"]),
      ]
-    ),
-])
+    )],
+    ids=['E.root.@test.data.string',
+         'E.root.@test.data.token.pattern',
+         'E.root.@test.data.token']
+)
 def test_transform_datatype(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)
@@ -496,10 +509,9 @@ def test_transform_datatype(xml, expected):
            True),
          ("boolean(/documentation/element[@name = 'test2']/attribute[@name = 'test_attribute2'])",
            True),
-     ]
-
-    ),
-])
+     ])],
+    ids=['G.ref.test2.attlist'],
+)
 def test_transform_references(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)
@@ -610,8 +622,10 @@ def test_transform_references(xml, expected):
          ("/documentation/element[@name = 'test2']/attribute[1]/type/value[@name = 'value2']/description/text()",
            ["A test value2"]),
      ]
-    ),
-])
+    )],
+    ids=['G.enum.without-docs',
+         'G.enum.with-docs'],
+)
 def test_transform_enumerations(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)
@@ -659,7 +673,9 @@ def test_transform_enumerations(xml, expected):
           True),
      ]
     ),
-])
+    ],
+    ids=['G.anyElement'],
+)
 def test_transform_name_classes(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)
@@ -888,9 +904,11 @@ def test_transform_name_classes(xml, expected):
          ("/documentation/element[@name = 'trans:test']/attribute/namespace/text()",
           []),
      ]
-    ),
-
-])
+    )],
+    ids=['G.E.test1', 'G.E.test2', 'G.E.test3', 'G.E.test4',
+         'G.E.test5', 'G.E.test6', 'G.E.test7',
+         ],
+)
 def test_transform_namespaces(xml, expected):
     result = parse(io.StringIO(xml))
     assert isinstance(result, etree._ElementTree)


### PR DESCRIPTION
This PR contains the following changes:

* Use `enumerate()` instead of incrementing index manually 
* Add more constants in `rng2doc.common`
* Add missing XML namespace and import NSMAP
* Improve `test_rng.py`: introduce ids args to avoid overlong lines in pytest output