### PR TITLE
Fix Issue 57: When called from a different directory, rng2doc fails to find relaxng.rng

### DIFF
--- a/src/rng2doc/rng.py
+++ b/src/rng2doc/rng.py
@@ -3,6 +3,7 @@
 
 # Standard Library
 import logging
+import subprocess
 
 # Third Party Libraries
 import pydot
@@ -122,7 +123,10 @@ def parse(rngfile):
     # Remove all blank lines, which makes the output later much more beautiful.
     xmlparser = etree.XMLParser(remove_blank_text=True, remove_comments=True)
 
-    relaxng_schema = etree.parse("schemas/relaxng.rng")
+    path_to_schema = subprocess.check_output(
+            ["find $(echo $HOME) -name relaxng.rng"], 
+            shell=True).strip().decode('ascii')
+    relaxng_schema = etree.parse(path_to_schema)
     relaxng = etree.RelaxNG(relaxng_schema)
     rngtree = etree.parse(rngfile, xmlparser)
     if not relaxng.validate(rngtree):


### PR DESCRIPTION
## Description
I have fixed the path for ```relaxng_schema``` which caused error if ```rng2doc``` was used inside a different directory.
Fixes Issue #57 

## About my approach:
Since we are limited to Linux environments, I thought maybe we can use the ```find``` command to accurately and dynamically locate the path to the rng file in the home directory of the user and use that as an input for ```etree.parse()```. I have used the ```subprocess module``` which is a default python module and have used the ```find``` command to scan recursively through the user's home directory to locate the ```relaxng.rng``` file. The ```path``` captured from ```stdout``` of find command is then used as the string input to ```etree.parse()``` which expects a valid path string as it's parameter.


