### PR TITLE
Fixes the handling of dupes

### DIFF
--- a/src/rng2doc/rng.py
+++ b/src/rng2doc/rng.py
@@ -38,7 +38,7 @@ def transform(node, output, **kwargs):
         if node.tag != RNG_ELEMENT.text:
             return output
         transform_func = template.get(node.tag)
-        transformed_node = transform_func(node, root=True, index=index)
+        transformed_node = transform_func(node, root=True, index=index, **kwargs)
         append(transformed_node, output, graph=output, root=True)
         parent = transformed_node
 
@@ -134,12 +134,21 @@ def parse(rngfile):
 
     documentation = etree.Element("documentation")
 
+    already_seen = []
+
     for element in elements:
         name = element.get("name")
         if name is None:
             name = "anyName"
+        if name in already_seen:
+            dupe = True
+            previous = documentation.find(f".//element[@name='{name}']")
+            previous.attrib["dupe"] = "true"
+        else:
+            already_seen.append(name)
+            dupe = False
         element_id = element.attrib["id"]
-        documentation, _ = transform(element, documentation, template=XML)
+        documentation, _ = transform(element, documentation, template=XML, dupe=dupe)
 
         name = '"' + name + '"'
         graph = pydot.Dot(graph_name=name, rankdir="LR", format="svg")

--- a/src/rng2doc/transforms/xml.py
+++ b/src/rng2doc/transforms/xml.py
@@ -13,6 +13,7 @@ from ..common import (A_DOC,
                       RNG_ATTRIBUTE,
                       RNG_CHOICE,
                       RNG_DATA,
+                      RNG_DEFINE,
                       RNG_ELEMENT,
                       RNG_OPTIONAL,
                       RNG_PARAM,
@@ -48,18 +49,28 @@ def transform_element(node, **kwargs):
     """Transforms a RELAX NG element into a new XML structure
     """
     root = kwargs.pop("root", False)
-    uuid = node.get("id")
-    name = node.get("name")
-    if name is None:
-        name = "anyName"
+    dupe = kwargs.pop("dupe", False)
+    attributes = {
+        "id": node.get("id"),
+        "name":  node.get("name"),
+    }
+    parent = node.getparent()
+    if parent is not None and parent.tag == RNG_DEFINE:
+        attributes["define"] = node.getparent().get("name")
+    if dupe:
+        attributes["dupe"] = "true"
+    else:
+        attributes["dupe"] = "false"
+    if attributes["name"] is None:
+        attributes["name"] = "anyName"
     if root:
         namespace = find_namespace(node)
-        element = etree.Element("element", name=name, id=uuid)
+        element = etree.Element("element", **attributes)
         element_namespace = etree.SubElement(element, "namespace")
         if namespace:
             element_namespace.text = namespace
     else:
-        element = etree.Element("child", id=uuid)
+        element = etree.Element("child", id=attributes["id"])
     return element
 
 

--- a/src/rng2doc/xslt/html.xslt
+++ b/src/rng2doc/xslt/html.xslt
@@ -26,6 +26,8 @@
 
   <xsl:key name="elementname" match="element" use="@name"/>
   <xsl:key name="elementid" match="element" use="@id"/>
+  <xsl:key name="elementdefine" match="element" use="@define"/>
+  <xsl:key name="elementdupe" match="element" use="@dupe"/>
   <xsl:key name="child" match="child" use="@id"/>
 
   <!-- === Parameters -->
@@ -75,7 +77,7 @@
                   <ul id="{$first_letter}" class="list-group">
                     <li class="list-group-item active"><xsl:value-of select="$first_letter"/></li>
                     <xsl:apply-templates select="key('first_letters', substring(@name, 1, 1))" mode="index">
-                      <xsl:sort select="@name" />
+                        <xsl:sort select="@name" />
                     </xsl:apply-templates>
                   </ul>
                 </div>
@@ -98,8 +100,17 @@
    <xsl:variable name="ename">
     <xsl:call-template name="create-filename"/>
    </xsl:variable>
-    <li class="list-group-item"><a href="elements/{$ename}.html"><code><xsl:value-of select="@name"/></code></a></li>
-  </xsl:template>  
+   <li class="list-group-item">
+     <a href="elements/{$ename}.html">
+       <code>
+        <xsl:value-of select="@name"/>
+        <xsl:if test="@define and @dupe = 'true'">
+          (<xsl:value-of select="@define"/>)
+        </xsl:if>
+       </code>
+     </a>
+   </li>
+  </xsl:template>
 
   <xsl:template match="element" mode="visualize">
     <!-- toms 2018-05-11
@@ -124,11 +135,17 @@
           <div class="container">
             <div class="card-columns">
 
-              <xsl:variable name="id" select="@id"/> 
+              <xsl:variable name="id" select="@id"/>
               <div class="card" id="element{$id}" name="element{$id}">
                 <div class="card-header">Element</div>
                 <div class="card-body">
-                  <h5 class="card-title"><xsl:value-of select="@name"/></h5>
+                    <h5 class="card-title">
+                        <xsl:value-of select="@name"/>
+                        <xsl:if test="@define and @dupe = 'true'">
+                            <xsl:text disable-output-escaping="yes"><![CDATA[&nbsp;]]></xsl:text>
+                            (<xsl:value-of select="@define"/>)
+                        </xsl:if>
+                    </h5>
                   <h6 class="card-subtitle mb-2 text-muted">
                     <!-- toms 2018-05-11: Not sure about the &nbsp; after "Namespace" -->
                     Namespace:<xsl:text disable-output-escaping="yes"><![CDATA[&nbsp;]]></xsl:text>
@@ -205,7 +222,7 @@
           <xsl:call-template name="scripts"/>
         </body>
       </html>
-    </exsl:document>  
+    </exsl:document>
   </xsl:template>
 
   <xsl:template match="element" mode="parent">
@@ -226,7 +243,7 @@
      <xsl:with-param name="node" select="$enode"/>
     </xsl:call-template>
    </xsl:variable>
-    <xsl:variable name="id" select="@id"/> 
+    <xsl:variable name="id" select="@id"/>
     <a href="{$ename}.html"><xsl:value-of select="$enode/@name"/></a>
     <xsl:if test="position() != last()">
        <xsl:value-of select="$sep"/>
@@ -343,7 +360,7 @@
       .graphviz-svg {
           width: 100%;
           height: 100%;
-          position: relative; 
+          position: relative;
       }
 
       #index {


### PR DESCRIPTION
XML:
* Adds the attribute define to the element documentation
* Adds the attribute dupe to the element documentation

Example:

    <element id="59" name="caption" define="db.caption" dupe="true">
     ...
    </element>
    <element id="268" name="caption" define="db.html.caption" dupe="true">
      ...
    </element>

HTML:
* Adds the name of the define tag to the naming in case of a dupe

Example:

    <li class="list-group-item">
      <a href="elements/caption-59.html"><code>caption (db.caption)</code></a>
    </li>

![image](https://user-images.githubusercontent.com/2422012/126418350-b750b2f4-9080-4ea6-900d-f3761ed53f9f.png)

Fixes: #31 

Signed-off-by: Jürgen Löhel <juergen@loehel.de>