### PR TITLE
Fix table overlapping with diagram

### DIFF
--- a/src/rng2doc/xslt/html.xslt
+++ b/src/rng2doc/xslt/html.xslt
@@ -358,8 +358,8 @@
       }
 
       .graphviz-svg {
-          width: 100%;
-          height: 100%;
+          width: auto;
+          height: auto;
           position: relative;
       }
 


### PR DESCRIPTION
This PR fixes the issue of overlapping table with the diagram.

Before:
![overlapping-before](https://user-images.githubusercontent.com/54893750/148567131-4553c606-9383-4e89-ad21-43273855ee0d.png)

After:
![overlapping-after](https://user-images.githubusercontent.com/54893750/148567218-7d050de5-d264-4a49-8e78-fcdd308fe643.png)

